### PR TITLE
Support for custom output directory

### DIFF
--- a/CodeGenerator/Main.cs
+++ b/CodeGenerator/Main.cs
@@ -54,6 +54,22 @@ namespace SilentOrbit.ProtocolBuffers
                     break;
                 }
 
+                // Handle custom output directory
+                else if (argIndex == args.Length && protoPath.EndsWith("\\"))
+                {
+                    string outputDir = Path.GetDirectoryName(protoPath);
+
+                    // Create the output directory if it doesn't exist
+                    if (Directory.Exists(outputDir) == false)
+                        Directory.CreateDirectory(outputDir);
+
+                    // Replace the original output directory with the custom one
+                    outputPath = Path.Combine(
+                            outputDir,
+                            Path.GetFileName(outputPath));
+                    break;
+                }
+
                 if (File.Exists(protoPath) == false)
                 {
                     Console.Error.WriteLine("File not found: " + protoPath);


### PR DESCRIPTION
Hi Peter,

Firstly, thanks for the amazing library that you've written! I started using it a few days ago for my new project and so far it seems really nice!

There was one feature that I was missing though - I needed to specify a custom output directory so that the files wouldn't get saved in the same source directory. I added a quick change to the Main class to do just that.

I totally agree that it's a bit dirty (you have to have a trailing slash in the path parameter), however it works flawlessly with both, relative and absolute directories. Not sure if you even want to pull this hack in but I'm creating a pull request nevertheless. Feel free to close it, you won't hurt my feelings :)

I would love add another functionality - saving each class in a separate file - however, after looking at the current code if looks to me that it would involve quite a bit of refactoring, hence the easiest solution for now is to have one message per file, which does the same thing, albeit not as neatly.

Regards,
Andris
