### PR TITLE
Make all messages serializable

### DIFF
--- a/CodeGenerator/CodeGenerator/MessageSerializer.cs
+++ b/CodeGenerator/CodeGenerator/MessageSerializer.cs
@@ -13,6 +13,7 @@ namespace SilentOrbit.ProtocolBuffers
                 cw.Bracket(m.OptionAccess + " static class " + m.SerializerType);
             } else
             {
+                cw.Attribute("System.Serializable()");
                 cw.Bracket(m.OptionAccess + " partial " + m.OptionType + " " + m.SerializerType);
             }
 
@@ -28,10 +29,10 @@ namespace SilentOrbit.ProtocolBuffers
             cw.WriteLine();
             return;
         }
-        
+
         static void GenerateReader(ProtoMessage m, CodeWriter cw)
         {
-            #region Helper Deserialize Methods
+#region Helper Deserialize Methods
             string refstr = (m.OptionType == "struct") ? "ref " : "";
             if (m.OptionType != "interface")
             {
@@ -41,21 +42,21 @@ namespace SilentOrbit.ProtocolBuffers
                 cw.WriteLine("Deserialize(stream, " + refstr + "instance);");
                 cw.WriteLine("return instance;");
                 cw.EndBracketSpace();
-                
+
                 cw.Summary("Helper: create a new instance to deserializing into");
                 cw.Bracket(m.OptionAccess + " static " + m.CsType + " DeserializeLengthDelimited(Stream stream)");
                 cw.WriteLine(m.CsType + " instance = new " + m.CsType + "();");
                 cw.WriteLine("DeserializeLengthDelimited(stream, " + refstr + "instance);");
                 cw.WriteLine("return instance;");
                 cw.EndBracketSpace();
-                
+
                 cw.Summary("Helper: create a new instance to deserializing into");
                 cw.Bracket(m.OptionAccess + " static " + m.CsType + " DeserializeLength(Stream stream, int length)");
                 cw.WriteLine(m.CsType + " instance = new " + m.CsType + "();");
                 cw.WriteLine("DeserializeLength(stream, length, " + refstr + "instance);");
                 cw.WriteLine("return instance;");
                 cw.EndBracketSpace();
-                
+
                 cw.Summary("Helper: put the buffer into a MemoryStream and create a new instance to deserializing into");
                 cw.Bracket(m.OptionAccess + " static " + m.CsType + " Deserialize(byte[] buffer)");
                 cw.WriteLine(m.CsType + " instance = new " + m.CsType + "();");
@@ -71,7 +72,7 @@ namespace SilentOrbit.ProtocolBuffers
             cw.WriteIndent("Deserialize(ms, " + refstr + "instance);");
             cw.WriteLine("return instance;");
             cw.EndBracketSpace();
-            #endregion
+#endregion
 
             string[] methods = new string[]{
                 "Deserialize", //Default old one
@@ -244,7 +245,7 @@ namespace SilentOrbit.ProtocolBuffers
             }
             if (m.IsUsingBinaryWriter)
                 cw.WriteLine("BinaryWriter bw = new BinaryWriter(stream);");
-            
+
             foreach (Field f in m.Fields.Values)
                 FieldSerializer.FieldWriter(m, f, cw);
 
@@ -270,4 +271,3 @@ namespace SilentOrbit.ProtocolBuffers
         }
     }
 }
-

--- a/CodeWriter/Code/CodeWriter.cs
+++ b/CodeWriter/Code/CodeWriter.cs
@@ -7,221 +7,225 @@ namespace SilentOrbit.ProtocolBuffers
     /// <summary>
     /// Static and instance helpers for code generation
     /// </summary>
-	public class CodeWriter : IDisposable
-	{ 
-        #region Settings
-		public static string IndentPrefix = "    ";
-        #endregion
+    public class CodeWriter : IDisposable
+    {
+#region Settings
+        public static string IndentPrefix = "    ";
+#endregion
 
-        #region Constructors
+#region Constructors
 
-		readonly TextWriter w;
-		MemoryStream ms = new MemoryStream();
+        readonly TextWriter w;
+        MemoryStream ms = new MemoryStream();
         /// <summary>
         /// Writes to memory, get the code using the "Code" property
         /// </summary>
-		public CodeWriter()
-		{
-			ms = new MemoryStream();
-			w = new StreamWriter(ms, Encoding.UTF8);
-			//w.NewLine = "\r\n"; // does not appear to work
-		}
+        public CodeWriter()
+        {
+            ms = new MemoryStream();
+            w = new StreamWriter(ms, Encoding.UTF8);
+            //w.NewLine = "\r\n"; // does not appear to work
+        }
         /// <summary>
         /// Return the generated code as a string.
         /// </summary>
-		public string Code
-		{
-			get
-			{
-				w.Flush();
-				return Encoding.UTF8.GetString(ms.ToArray());
-			}
-		}
+        public string Code
+        {
+            get
+            {
+                w.Flush();
+                return Encoding.UTF8.GetString(ms.ToArray());
+            }
+        }
         /// <summary>
         /// Writes code directly to file
         /// </summary>
-		public CodeWriter(string csPath)
-		{
-			w = new StreamWriter(csPath, false, Encoding.UTF8);
-		}
+        public CodeWriter(string csPath)
+        {
+            w = new StreamWriter(csPath, false, Encoding.UTF8);
+        }
 
-		public virtual void Flush()
-		{
-			w.Flush();
-		}
+        public virtual void Flush()
+        {
+            w.Flush();
+        }
 
-		public virtual void Dispose()
-		{
-			w.Close();
-		}
-        #endregion
+        public virtual void Dispose()
+        {
+            w.Close();
+        }
+#endregion
 
-        #region Indentation
+#region Indentation
 
         /// <summary>
         /// Level of indentation
         /// </summary>
-		public int IndentLevel { get; private set; }
+        public int IndentLevel { get; private set; }
         /// <summary>
         /// Accumulated prefixes over indentations
         /// </summary>
-		string prefix = "";
+        string prefix = "";
 
-		public void Indent()
-		{
-			IndentLevel += 1;
-			prefix += IndentPrefix;
-		}
+        public void Indent()
+        {
+            IndentLevel += 1;
+            prefix += IndentPrefix;
+        }
 
-		public void Dedent()
-		{
-			IndentLevel -= 1;
-			if (IndentLevel < 0)
-				throw new InvalidOperationException("Indent error");
-			prefix = prefix.Substring(0, prefix.Length - IndentPrefix.Length);
-		}
-        #endregion
+        public void Dedent()
+        {
+            IndentLevel -= 1;
+            if (IndentLevel < 0)
+                throw new InvalidOperationException("Indent error");
+            prefix = prefix.Substring(0, prefix.Length - IndentPrefix.Length);
+        }
+#endregion
+
+        public void Attribute(string str)
+        {
+            WriteLine("[" + str + "]");
+        }
 
         /// <summary>
         /// Write leading bracket and indent
         /// </summary>
         /// <param name="str">String.</param>
-		public void Bracket()
-		{
-			WriteLine("{");
-			Indent();
-		}
+        public void Bracket()
+        {
+            WriteLine("{");
+            Indent();
+        }
         /// <summary>
         /// Write leading bracket and indent
         /// </summary>
         /// <param name="str">Line before bracket</param>
-		public void Bracket(string str)
-		{
-			WriteLine(str);
-			WriteLine("{");
-			Indent();
-		}
+        public void Bracket(string str)
+        {
+            WriteLine(str);
+            WriteLine("{");
+            Indent();
+        }
 
-		public void Using(string str)
-		{
-			WriteLine("using (" + str + ")");
-			WriteLine("{");
-			Indent();
-		}
+        public void Using(string str)
+        {
+            WriteLine("using (" + str + ")");
+            WriteLine("{");
+            Indent();
+        }
 
-		public void IfBracket(string str)
-		{
-			WriteLine("if (" + str + ")");
-			WriteLine("{");
-			Indent();
-		}
+        public void IfBracket(string str)
+        {
+            WriteLine("if (" + str + ")");
+            WriteLine("{");
+            Indent();
+        }
 
-		public void WhileBracket(string str)
-		{
-			WriteLine("while (" + str + ")");
-			WriteLine("{");
-			Indent();
-		}
+        public void WhileBracket(string str)
+        {
+            WriteLine("while (" + str + ")");
+            WriteLine("{");
+            Indent();
+        }
 
-		public void Switch(string str)
-		{
-			Bracket("switch (" + str + ")");
-		}
+        public void Switch(string str)
+        {
+            Bracket("switch (" + str + ")");
+        }
 
-		public void Case(string str)
-		{
-			Dedent();
-			WriteLine("case " + str + ":");
-			Indent();
-		}
+        public void Case(string str)
+        {
+            Dedent();
+            WriteLine("case " + str + ":");
+            Indent();
+        }
 
-		public void Case(int id)
-		{
-			Dedent();
-			WriteLine("case " + id + ":");
-			Indent();
-		}
+        public void Case(int id)
+        {
+            Dedent();
+            WriteLine("case " + id + ":");
+            Indent();
+        }
 
-		public void CaseDefault()
-		{
-			Dedent();
-			WriteLine("default:");
-			Indent();
-		}
+        public void CaseDefault()
+        {
+            Dedent();
+            WriteLine("default:");
+            Indent();
+        }
 
-		public void ForeachBracket(string str)
-		{
-			WriteLine("foreach (" + str + ")");
-			WriteLine("{");
-			Indent();
-		}
+        public void ForeachBracket(string str)
+        {
+            WriteLine("foreach (" + str + ")");
+            WriteLine("{");
+            Indent();
+        }
 
-		public void EndBracket()
-		{
-			Dedent();
-			WriteLine("}");
-		}
+        public void EndBracket()
+        {
+            Dedent();
+            WriteLine("}");
+        }
 
-		public void EndBracketSpace()
-		{
-			Dedent();
-			WriteLine("}");
-			WriteLine();
-		}
+        public void EndBracketSpace()
+        {
+            Dedent();
+            WriteLine("}");
+            WriteLine();
+        }
         /// <summary>
         /// Writes a singe line indented.
         /// </summary>
-		public void WriteIndent(string str)
-		{
-			WriteLine(IndentPrefix + str);
-		}
+        public void WriteIndent(string str)
+        {
+            WriteLine(IndentPrefix + str);
+        }
 
-		public void WriteLine(string line)
-		{
-			string[] lines = line.Split('\n');
-			foreach (string l in lines)
-			{
-				w.Write(prefix + l + "\r\n");
-			}
-		}
+        public void WriteLine(string line)
+        {
+            string[] lines = line.Split('\n');
+            foreach (string l in lines)
+            {
+                w.Write(prefix + l + "\r\n");
+            }
+        }
 
-		public void WriteLine()
-		{
-			WriteLine(prefix.TrimEnd(' '));
-		}
-        #region Comments
+        public void WriteLine()
+        {
+            WriteLine(prefix.TrimEnd(' '));
+        }
+#region Comments
 
-		public void Comment(string code)
-		{
-			if (code == null)
-				return;
+        public void Comment(string code)
+        {
+            if (code == null)
+                return;
 
-			prefix += "// ";
-			foreach (string line in code.Split('\n'))
-				WriteLine(line.TrimEnd(' '));
-			prefix = prefix.Substring(0, prefix.Length - 3);
-		}
+            prefix += "// ";
+            foreach (string line in code.Split('\n'))
+                WriteLine(line.TrimEnd(' '));
+            prefix = prefix.Substring(0, prefix.Length - 3);
+        }
 
-		public void Summary(string summary)
-		{
-			if (summary == null || summary.Trim() == "")
-				return;
+        public void Summary(string summary)
+        {
+            if (summary == null || summary.Trim() == "")
+                return;
 
-			string[] lines = summary.Replace("\r\n", "\n").Split('\n');
-			if (lines.Length == 1)
-			{
-				WriteLine("/// <summary>" + summary.TrimEnd(' ') + "</summary>");
-				return;
-			}
+            string[] lines = summary.Replace("\r\n", "\n").Split('\n');
+            if (lines.Length == 1)
+            {
+                WriteLine("/// <summary>" + summary.TrimEnd(' ') + "</summary>");
+                return;
+            }
 
-			prefix += "/// ";
-			WriteLine("<summary>");
-			foreach (string line in lines)
-				WriteLine("<para>" + line.TrimEnd(' ') + "</para>");
-			WriteLine("</summary>");
-			prefix = prefix.Substring(0, prefix.Length - 4);
-		}
-        #endregion
-	}
+            prefix += "/// ";
+            WriteLine("<summary>");
+            foreach (string line in lines)
+                WriteLine("<para>" + line.TrimEnd(' ') + "</para>");
+            WriteLine("</summary>");
+            prefix = prefix.Substring(0, prefix.Length - 4);
+        }
+#endregion
+    }
 }
-


### PR DESCRIPTION
Given that the foundation of all protocol messages are primitives, there is no reason why one shouldn't be able to serialize them. This way, the enduser can cache the message using any formatter he or she wants.
