### PR TITLE
Default value for fields

### DIFF
--- a/CodeGenerator/CodeGenerator/MessageCode.cs
+++ b/CodeGenerator/CodeGenerator/MessageCode.cs
@@ -1,5 +1,6 @@
 using System;
 using SilentOrbit.Code;
+using System.Collections.Generic;
 
 namespace SilentOrbit.ProtocolBuffers
 {
@@ -18,6 +19,8 @@ namespace SilentOrbit.ProtocolBuffers
             //Default class
             cw.Summary(m.Comments);
             cw.Bracket(m.OptionAccess + " partial " + m.OptionType + " " + m.CsType);
+
+            GenerateCtorForDefaults(m, cw);
 
             GenerateEnums(m, cw);
 
@@ -47,6 +50,31 @@ namespace SilentOrbit.ProtocolBuffers
             }
             cw.EndBracket();
             return;
+        }
+
+        static void GenerateCtorForDefaults(ProtoMessage m, CodeWriter cw)
+        {
+            // Collect all fields with default values.
+            var fieldsWithDefaults = new List<Field>();
+            foreach (Field field in m.Fields.Values)
+            {
+                if (field.OptionDefault != null)
+                {
+                    fieldsWithDefaults.Add(field);
+                }
+            }
+
+            if (fieldsWithDefaults.Count > 0)
+            {
+                cw.Bracket("public " + m.CsType + "()");
+                foreach (var field in fieldsWithDefaults)
+                {
+                    string formattedValue = field.FormatForTypeAssignment(field.OptionDefault);
+                    string line = string.Format("{0} = {1};", field.CsName, formattedValue);
+                    cw.WriteLine(line);
+                }
+                cw.EndBracket();
+            }
         }
 
         static void GenerateEnums(ProtoMessage m, CodeWriter cw)

--- a/CodeGenerator/CodeGenerator/MessageSerializer.cs
+++ b/CodeGenerator/CodeGenerator/MessageSerializer.cs
@@ -125,7 +125,7 @@ namespace SilentOrbit.ProtocolBuffers
                         if (f.ProtoType is ProtoEnum)
                             cw.WriteLine("instance." + f.CsName + " = " + f.ProtoType.FullCsType + "." + f.OptionDefault + ";");
                         else
-                            cw.WriteLine("instance." + f.CsName + " = " + f.OptionDefault + ";");
+                            cw.WriteLine("instance." + f.CsName + " = " + f.FormatForTypeAssignment(f.OptionDefault) + ";");
                     }
                     else if (f.Rule == FieldRule.Optional)
                     {

--- a/CodeGenerator/Proto/Field.cs
+++ b/CodeGenerator/Proto/Field.cs
@@ -118,6 +118,23 @@ namespace SilentOrbit.ProtocolBuffers
         /// </summary>
         public ProtoType ProtoType { get; set; }
         #endregion
+
+        /// <summary>
+        /// Format the specified value according to the field type.
+        /// </summary>
+        /// <returns>String that can be use to assign to field of this field's type.</returns>
+        /// <param name="value">Value.</param>
+        public string FormatForTypeAssignment(string value)
+        {
+            string formattedValue = value;
+            if (ProtoTypeName == "string")
+            {
+                formattedValue = string.Format("\"{0}\"", value);
+            }
+
+            return formattedValue;
+        }
+
         public override string ToString()
         {
             return string.Format("{0} {1} {2} = {3}", Rule, ProtoTypeName, ProtoName, ID);


### PR DESCRIPTION
The default values are now respected in the message class and when the field type is string the default value is properly formatted.

This fixes #21